### PR TITLE
Update base URL

### DIFF
--- a/lib/nordigen-ruby.rb
+++ b/lib/nordigen-ruby.rb
@@ -8,7 +8,7 @@ require_relative "nordigen_ruby/api/account"
 module Nordigen
     class NordigenClient
 
-        BASE_URL = "https://ob.nordigen.com/api/v2/"
+        BASE_URL = "https://bankaccountdata.gocardless.com/api/v2/"
 
         @@headers = {
             "accept" => "application/json",


### PR DESCRIPTION
```
Dear user,

We are contacting you to make sure you are using an up-to-date base_url for the GoCardless Bank Account Data API.
This small but important change which should be easy to make for anyone in your team who has access to the production setup of your service. The new connection string should be:
https://bankaccountdata.gocardless.com/api/v2/

The legacy URLs such as [ob.nordigen.com](http://ob.nordigen.com/) and [ob.gocardless.com](http://ob.gocardless.com/) will stop working on the 20th of February.

If you are using any of our public libraries, they are updated and can be found here:
https://developer.gocardless.com/bank-account-data/libraries

We would also like to inform you that there is maintenance window (with downtime) scheduled for 20.02.2024 between 03:00 and 05:00 UTC. You follow its progress on our statuspage:
https://status.nordigen.com/

If you have any questions, feel free to contact support by replying to this mail and will be happy to assist you.

Working on an ever better service,
Bank Account Data Team
```
